### PR TITLE
Fixed create and update shopscript

### DIFF
--- a/src/WebshopappApiClient.php
+++ b/src/WebshopappApiClient.php
@@ -4046,7 +4046,7 @@ class WebshopappApiResourceShopScripts
      */
     public function create($fields)
     {
-        $fields = array('script' => $fields);
+        $fields = array('shopScript' => $fields);
 
         return $this->client->create('shop/scripts', $fields);
     }
@@ -4087,7 +4087,7 @@ class WebshopappApiResourceShopScripts
      */
     public function update($scriptId, $fields)
     {
-        $fields = array('script' => $fields);
+        $fields = array('shopScript' => $fields);
 
         return $this->client->update('shop/scripts/' . $scriptId, $fields);
     }


### PR DESCRIPTION
Out of the box, creating and updating shopscripts triggers an error 400 'Invalid data input'. These changes fixes both calls.
