### PR TITLE
Fix for WebshopappApiResourceOrdersCredit::create

### DIFF
--- a/src/WebshopappApiClient.php
+++ b/src/WebshopappApiClient.php
@@ -3611,7 +3611,7 @@ class WebshopappApiResourceOrdersCredit
      */
     public function create($orderId, $fields)
     {
-        $fields = array('creditInvoice' => $fields);
+        $fields = array('credit' => $fields);
 
         return $this->client->create('orders/' . $orderId . '/credit', $fields);
     }


### PR DESCRIPTION
The documentation states that the fields should be under key 'credit' instead of 'creditInvoice'. Testing proves that this change is required to make WebshopappApiResourceOrdersCredit::create work (otherwise it results in an error 'Credit invoice be created. No items specified', which just creates a credit order for the shipping costs).
