### PR TITLE
Fix for US cluster

### DIFF
--- a/src/WebshopappApiClient.php
+++ b/src/WebshopappApiClient.php
@@ -8,7 +8,7 @@ class WebshopappApiClient
     /**
      * The Api Client version (do not change!)
      */
-    const CLIENT_VERSION = '1.7.0';
+    const CLIENT_VERSION = '1.7.1';
     /**
      * The Api Hosts (do not change!)
      */
@@ -766,6 +766,7 @@ class WebshopappApiClient
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_SSL_VERIFYPEER => false,
             CURLOPT_USERAGENT      => 'WebshopappApiClient/' . self::CLIENT_VERSION . ' (PHP/' . phpversion() . ')',
+            CURLOPT_SSLVERSION => 6,
         );
 
         $curlHandle = curl_init();


### PR DESCRIPTION
The US cluster has a newer SSL certificate installed. If you don't enforce TLS, you'll get the error "[WebshopappApiException] Curl error: SSL connect error".

More detailed, using curl on the console (CentOS 6 with all updates installed) returns:

```
# curl -vvv https://api.shoplightspeed.com/
* About to connect() to api.shoplightspeed.com port 443 (#0)
*   Trying 54.165.255.117... connected
* Connected to api.shoplightspeed.com (54.165.255.117) port 443 (#0)
* Initializing NSS with certpath: sql:/etc/pki/nssdb
*   CAfile: /etc/pki/tls/certs/ca-bundle.crt
  CApath: none
* NSS error -5961
* Closing connection #0
* SSL connect error
curl: (35) SSL connect error
```

```
# curl -vvv  --tlsv1.2 https://api.shoplightspeed.com/
```

does work, proving it's in the TLS enforcing.
