### PR TITLE
Added a specific exception that can be used to branch on API rate limit errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "php": ">=5.3.0",
         "ext-curl": "*",
         "ext-json": "*",
-        "ext-mbstring": "*"
+        "ext-mbstring": "*",
+        "guzzlehttp/guzzle": "6.*"
     },
     "autoload": {
         "files": ["src/WebshopappApiClient.php"]


### PR DESCRIPTION
Hi, the current SDK did not allow to see the API rate limit info that is contained in the HTTP response headers. We replaced Curl with the Guzzle HTTP library and added a specific exception class that can be used to branch on API rate limit errors. The exception class has getter methods to retrieve the API limit settings, remaining calls and the time to reset. The exception will be thrown in case a HTTP status code 429 is returned by the API. The exception extends from the existing WebshopappApiException for backward compatibility.