### PR TITLE
Fixed issue where checkouts could not be converted to orders

### DIFF
--- a/src/WebshopappApiClient.php
+++ b/src/WebshopappApiClient.php
@@ -2050,13 +2050,13 @@ class WebshopappApiResourceCheckoutsOrder
     }
 
     /**
-     * @param int $checkoutId
+     * @param int   $checkoutId
      * @param array $fields
      *
      * @return array
      * @throws WebshopappApiException
      */
-    public function create($checkoutId, $fields)
+    public function create($checkoutId, $fields = [])
     {
         return $this->client->create('checkouts/' . $checkoutId . '/order', $fields);
     }


### PR DESCRIPTION
As referenced in: https://github.com/SEOshop/API-PHP-Client/issues/24

The issue was related to the requirement of an payload in every create action, while this specific method only required a post request without any payload.
